### PR TITLE
🚑️ Fix: 게시물 목록 페이지에서 반응이 즉각적으로 피드백되지 않는 오류 수정

### DIFF
--- a/src/components/Post/PostList/PostSummary.tsx
+++ b/src/components/Post/PostList/PostSummary.tsx
@@ -35,24 +35,24 @@ export function PostSummary({ channelId, boardId, postId, post }:
     if (newIsUpvoting === NULL) {
       await deletePostReaction(channelId, boardId, postId);
       if (isUpvoting === TRUE) {
-        setUpvotes(upvotes - 1n);
+        setUpvotes(BigInt(upvotes) - 1n);
       } else {
-        setDownvotes(downvotes - 1n);
+        setDownvotes(BigInt(downvotes) - 1n);
       }
       setIsUpvoting(NULL);
     } else {
       await updatePostReaction(channelId, boardId, postId, (newIsUpvoting === TRUE));
       if (isUpvoting !== NULL) {
         if (newIsUpvoting === TRUE) {
-          setDownvotes(downvotes - 1n);
+          setDownvotes(BigInt(downvotes) - 1n);
         } else {
-          setUpvotes(upvotes - 1n);
+          setUpvotes(BigInt(upvotes) - 1n);
         }
       }
       if (newIsUpvoting === TRUE) {
-        setUpvotes(upvotes + 1n);
+        setUpvotes(BigInt(upvotes) + 1n);
       } else {
-        setDownvotes(downvotes + 1n);
+        setDownvotes(BigInt(downvotes) + 1n);
       }
       setIsUpvoting(newIsUpvoting);
     }


### PR DESCRIPTION
# 작업사항
- [x] 게시물 조회 페이지에서 게시물의 좋아요/싫어요 반응이 추가되었을 경우 바로 렌더링(피드백)되지 않는 오류 수정