### PR TITLE
Fix: 내 리뷰 외 다른 리뷰의 별점이 왼쪽으로 정렬되는 부분 수정

### DIFF
--- a/src/components/game-review/GameReviewItem.tsx
+++ b/src/components/game-review/GameReviewItem.tsx
@@ -100,29 +100,36 @@ function GameReviewItem(item: GameReviewItem) {
       <Paper bd="1px solid dark.9" mt={20} pl={20} pr={20}>
         <h2>{item.gameTitle}</h2>
         <Group justify="space-between">
-          {item.memberId === memberId && (
-            <Group>
-              <span>{dateFormat(item.createdAt)}</span>
-              <Button type="button" onClick={() => setIsEditing(true)} size="compact-xs">
-                수정
-              </Button>
-              <Button
-                type="button"
-                size="compact-xs"
-                onClick={() => {
-                  if (window.confirm('정말 삭제하시겠습니까?')) {
-                    deleteGameReview(String(item.id));
-                    window.location.reload();
-                  }
-                }}
-              >
-                삭제
-              </Button>
-            </Group>
-          )}
+          <Group>
+            <span>{dateFormat(item.createdAt)}</span>
+            {item.memberId === memberId && (
+              <Group>
+                <Button type="button" onClick={() => setIsEditing(true)} size="compact-xs">
+                  수정
+                </Button>
+                <Button
+                  type="button"
+                  size="compact-xs"
+                  onClick={() => {
+                    if (window.confirm('정말 삭제하시겠습니까?')) {
+                      deleteGameReview(String(item.id));
+                      window.location.reload();
+                    }
+                  }}
+                >
+                  삭제
+                </Button>
+              </Group>
+            )}
+          </Group>
           <GameReviewScore score={Number(point)} />
         </Group>
-        <Paper className="game-review-item-content" style={{ whiteSpace: 'pre-wrap' }}>
+        <Paper
+          className="game-review-item-content"
+          style={{ whiteSpace: 'pre-wrap' }}
+          mt={20}
+          mb={20}
+        >
           {description}
         </Paper>
         <Group justify="flex-end" mb={20}>


### PR DESCRIPTION
# 개요

게임리뷰 점수 관련 변경점

# 작업사항

- [x] 나의 리뷰 외 다른 리뷰의 점수가 왼쪽으로 이동되는 현상 수정
- [x] 나의 리뷰 외 다른 리뷰의 날짜가 보이지 않는 현상 수정 
- [x] 리뷰 내용 위, 아래 마진 추가  

# 관련 이슈

- close #52 
